### PR TITLE
Updated dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "url" : "https://github.com/wbkd/dsv-loader/issues"
   },
   "dependencies": {
-    "dsv": "0.0.4",
-    "loader-utils": "^0.2.6"
+    "d3-dsv": "0.1.12",
+    "loader-utils": "^0.2.12"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The [`dsv`](https://www.npmjs.com/package/dsv) library has been renamed to [`d3-dsv`](https://www.npmjs.com/package/d3-dsv). 

This pull request:
- Migrates from `dsv` to `d3-dsv`.
- Updates the loader-utils library. 

Fixes issue #1 
