### PR TITLE
Require d3-dsv with correct module name

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
     built using dsv by Mike Bostock */
 
 var loaderUtils = require('loader-utils');
-var dsv = require('dsv');
+var dsv = require('d3-dsv');
 
 module.exports = function(text) {
 


### PR DESCRIPTION
Previous commits fixed module name in package.json but not in index.js
