### PR TITLE
Reference dsv function

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
     built using dsv by Mike Bostock */
 
 var loaderUtils = require('loader-utils');
-var dsv = require('d3-dsv');
+var dsv = require('d3-dsv').dsv;
 
 module.exports = function(text) {
 


### PR DESCRIPTION
Forgot to reference the function within the d3-dsv module in the last commit.
