### PR TITLE
Mark the loader as cacheable

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ var loaderUtils = require('loader-utils');
 var dsv = require('d3-dsv').dsv;
 
 module.exports = function(text) {
-
+  this.cacheable();
+  
   var query = loaderUtils.parseQuery(this.query),
       delimiter = query.delimiter || ',',
       parser = dsv(delimiter),


### PR DESCRIPTION
Makes the results of dsv-loader cacheable using the loader API documented [here](https://webpack.github.io/docs/how-to-write-a-loader.html#flag-itself-cacheable-if-possible).

When using tools like webpack-dev-server to recompile on change in development this makes the overall build much faster.

Removing the delay on rebuilding has a particularly positive effect on hot reloading.
