### PR TITLE
Update to released d3-dsv and add rows option

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,15 +2,16 @@
     built using dsv by Mike Bostock */
 
 var loaderUtils = require('loader-utils');
-var dsv = require('d3-dsv').dsv;
+var dsvFormat = require('d3-dsv').dsvFormat;
 
 module.exports = function(text) {
   this.cacheable();
   
   var query = loaderUtils.parseQuery(this.query),
       delimiter = query.delimiter || ',',
-      parser = dsv(delimiter),
-      res = parser.parse(text);
+      dsv = dsvFormat(delimiter),
+      rows = query.rows,
+      res = rows ? dsv.parseRows(text) : dsv.parse(text);
 
   return 'module.exports = ' + JSON.stringify(res);
 }

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "url": "https://github.com/wbkd/dsv-loader/issues"
   },
   "dependencies": {
-    "d3-dsv": "^0.1.12",
-    "loader-utils": "^0.2.12"
+    "d3-dsv": "^1.0.0",
+    "loader-utils": "^0.2.15"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This loader is pretty handy.

This PR updates the d3-dsv dependency to the latest released version, and adds support for the `parseRows` option.
