### PR TITLE
Added some more info about calling dsv-loader to the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ module : {
 }
 ```
 
+---
+
+**Note**: Do not use both the `webpack.config` setup and the `dsv!` prefix to load DSV data, or it will be parsed twice. When loading anything other than CSV data, the `dsv!delimiter=x` option should be used and no modifications to the `webpack.config` file should be made.
+
 #### Options
 
 **delimiter**


### PR DESCRIPTION
First of all thank you for your work on this loader; I'm a bit of a novice at webpack and this helped get some semicolon separated files into our app quickly. Unfortunately, due to not knowing webpack loaders well, I wasted quite a bit of time wondering why some data I was importing was being represented incorrectly, and it turned out it was due to having both a `webpack.config` loader configured as well as using the `dsv!` prefix in my require statements. The combo will parse data twice, leading to incorrect data. I wanted to add a note in the readme for others that aren't familiar with webpack loaders that only one or the other should be used, and in the case of non-comma-delimited data, only the `dsv!prefix=x` should be used. Thanks!